### PR TITLE
Patch github workflow to zip only website related files

### DIFF
--- a/.github/workflows/update_website.yml
+++ b/.github/workflows/update_website.yml
@@ -11,8 +11,8 @@ jobs:
     name: Upload code to lambda
 
     permissions:
-    id-token: write
-    contents: read
+      id-token: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,8 +25,8 @@ jobs:
         
       - name: Zip lambda code files
         run: |
-          zip -r temp/lambda_code.zip .
+          cd lambda_code && zip -r lambda_code.zip .
 
       - name: Update lambda function with new code files
         run: |
-          aws lambda update-function-code --function-name  Website --zip-file fileb://lambda_code.zip
+          cd lambda_code && aws lambda update-function-code --function-name  Website --zip-file fileb://lambda_code.zip


### PR DESCRIPTION
Currently the zip step was archiving all files in the repo, we only need to zip the files inside lambda_code directory.