### PR TITLE
Add terraform script to automate creating IAM role for github actions

### DIFF
--- a/automation/github-actions.tf
+++ b/automation/github-actions.tf
@@ -1,0 +1,50 @@
+// To create the OIDC provider for github actions to work
+// Due to lack of time, this entire functionality was build following the guide here https://dev.to/mmiranda/github-actions-authenticating-on-aws-using-oidc-3d2n
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"] // Constant for github
+}
+
+
+data "aws_iam_policy_document" "github_actions_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions" {
+  name               = "github-actions"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_actions" {
+  statement {
+    actions = [
+      "lambda:UpdateFunctionCode"
+    ]
+    resources = [aws_lambda_function.lambda_website.arn]
+  }
+}
+
+resource "aws_iam_policy" "github_actions" {
+  name        = "github-actions"
+  description = "Allow Github Actions to update code in lambda"
+  policy      = data.aws_iam_policy_document.github_actions.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_actions" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.github_actions.arn
+}
+


### PR DESCRIPTION
Add terraform script to automate creating IAM roles, policies and identity provider to allow GitHub-actions to access AWS account and perform lambda `UpdateFunctionCode` Action.